### PR TITLE
Improved compatibility with different entity type ids

### DIFF
--- a/app/code/community/Fballiano/ImageCleaner/Block/Adminhtml/Fbimagecleaner/Grid.php
+++ b/app/code/community/Fballiano/ImageCleaner/Block/Adminhtml/Fbimagecleaner/Grid.php
@@ -45,10 +45,10 @@ class Fballiano_ImageCleaner_Block_Adminhtml_Fbimagecleaner_Grid extends Mage_Ad
             'align' => 'center',
             'index' => 'entity_type_id',
             'options' => array(
-                3 => $this->__('Category'),
-                4 => $this->__('Product'),
-                -3 => $this->__('Category Cache'),
-                -4 => $this->__('Product Cache'),
+                Mage::getModel('catalog/category')->getResource()->getTypeId() => $this->__('Category'),
+                Mage::getModel('catalog/product')->getResource()->getTypeId() => $this->__('Product'),
+                -Mage::getModel('catalog/category')->getResource()->getTypeId() => $this->__('Category Cache'),
+                -Mage::getModel('catalog/product')->getResource()->getTypeId() => $this->__('Product Cache'),
                 -98 => $this->__('WYSIWYG'),
             )
         ));

--- a/app/code/community/Fballiano/ImageCleaner/Block/Adminhtml/Fbimagecleaner/Renderer/Image.php
+++ b/app/code/community/Fballiano/ImageCleaner/Block/Adminhtml/Fbimagecleaner/Renderer/Image.php
@@ -18,16 +18,16 @@ class Fballiano_ImageCleaner_Block_Adminhtml_Fbimagecleaner_Renderer_Image exten
         $max_width = Mage::getStoreConfig('admin/fb_image_cleaner/thumbnail_max_width');
 
         switch ($row->getEntityTypeId()) {
-            case 3:
+            case Mage::getModel('catalog/category')->getResource()->getTypeId():
                 $url .= "catalog/category/";
                 break;
-            case 4:
+            case Mage::getModel('catalog/product')->getResource()->getTypeId():
                 $url .= "catalog/product/";
                 break;
-            case -3:
+            case -Mage::getModel('catalog/category')->getResource()->getTypeId():
                 $url .= "catalog/category/cache/";
                 break;
-            case -4:
+            case -Mage::getModel('catalog/product')->getResource()->getTypeId():
                 $url .= "catalog/product/cache/";
                 break;
             case -98:

--- a/app/code/community/Fballiano/ImageCleaner/controllers/Adminhtml/FbimagecleanerController.php
+++ b/app/code/community/Fballiano/ImageCleaner/controllers/Adminhtml/FbimagecleanerController.php
@@ -27,7 +27,7 @@ class Fballiano_ImageCleaner_Adminhtml_FbimagecleanerController extends Mage_Adm
 
     public function synccategoryAction()
     {
-        $entity_type_id = 3;
+        $entity_type_id = Mage::getModel('catalog/category')->getResource()->getTypeId();
         $media_dir = Mage::getBaseDir('media') . '/catalog/category';
         $resource = Mage::getSingleton('core/resource');
         $db = $resource->getConnection('core_read');
@@ -65,7 +65,7 @@ class Fballiano_ImageCleaner_Adminhtml_FbimagecleanerController extends Mage_Adm
 
     public function syncproductAction()
     {
-        $entity_type_id = 4;
+        $entity_type_id = Mage::getModel('catalog/product')->getResource()->getTypeId();
         $media_dir = Mage::getBaseDir('media') . '/catalog/product';
         $resource = Mage::getSingleton('core/resource');
         $db = $resource->getConnection('core_read');
@@ -114,7 +114,7 @@ class Fballiano_ImageCleaner_Adminhtml_FbimagecleanerController extends Mage_Adm
 
     public function syncproductCacheAction()
     {
-        $entity_type_id = -4;
+        $entity_type_id = -Mage::getModel('catalog/product')->getResource()->getTypeId();
         $media_dir = Mage::getBaseDir('media') . '/catalog/product/cache';
         $media_dir_nocache = Mage::getBaseDir('media') . '/catalog/product';
         $resource = Mage::getSingleton('core/resource');


### PR DESCRIPTION
Somehow some installations may have different entity_type_id values. (it happened to me)
This fix fetches correct entity_type_id from `eav_entity_type` table.